### PR TITLE
Chapter only raise error if they're the first to notice

### DIFF
--- a/lib/story_teller/book.rb
+++ b/lib/story_teller/book.rb
@@ -21,10 +21,12 @@ class StoryTeller::Book
       returned_value = nil
       returned_value = yield(chapter) if block_given?
     rescue StandardError => error
-      tell(StoryTeller::Error.new(error))
+      if error != chapter.uncaught_error
+        tell(StoryTeller::Error.new(error))
+      end
       raise error
     ensure
-      finish!
+      finish!(error: error)
       returned_value
     end
   end
@@ -69,8 +71,10 @@ class StoryTeller::Book
     chapter
   end
 
-  def finish!
-    @chapters.pop
+  def finish!(error: nil)
+    chapter = @chapters.pop
+    current_chapter.uncaught_error = error
+    chapter
   end
 
   def to_json(story)

--- a/lib/story_teller/chapter.rb
+++ b/lib/story_teller/chapter.rb
@@ -1,10 +1,11 @@
 class StoryTeller::Chapter
-  attr_reader :title, :subtitle
+  attr_reader :title, :subtitle, :uncaught_error
 
   def initialize(title:, subtitle: nil)
     @title = title
     @subtitle = Identifier.new(subtitle).value
     @attributes = {}
+    @uncaught_error
   end
 
   def to_hash
@@ -26,6 +27,10 @@ class StoryTeller::Chapter
     hash.each_pair do |key, value|
       @attributes[key.to_sym] = value
     end
+  end
+
+  def uncaught_error=(error)
+    @uncaught_error = error
   end
 
   class Identifier


### PR DESCRIPTION
Previous implementation would have created an error story for each of
the chapter that saw the error. By storing the last uncaught error in
the current chapter after popping, it allows us to recover error within
another chapter and also catching any other error that would be
triggered.

That makes it for a cleaner API that will only log exception once while
keeping the same behavior of catching errors inside chapters as before.