### PR TITLE
Remove message requirement

### DIFF
--- a/lib/story_teller/message.rb
+++ b/lib/story_teller/message.rb
@@ -4,10 +4,14 @@ class StoryTeller::Message
   NIL_STRING = ""
 
   def initialize(template)
-    return if template.nil? || template.empty?
+    if template.nil?
+      @template = ""
+      return
+    end
 
     unless template.encoding.name == "UTF-8"
-      template = template.encode("UTF-8", invalid: :replace)
+      @template = template.encode("UTF-8", invalid: :replace)
+      return
     end
 
     @template = template
@@ -21,10 +25,6 @@ class StoryTeller::Message
     template % attributes
   rescue StandardError => e
     e.message
-  end
-
-  def valid?
-    @template.present?
   end
 
   private

--- a/lib/story_teller/story.rb
+++ b/lib/story_teller/story.rb
@@ -1,6 +1,4 @@
 class StoryTeller::Story
-  class StoryAttributeMissingError < StandardError; end
-
   attr_accessor :timestamp
   attr_reader :attributes, :type, :message, :level
 
@@ -10,10 +8,6 @@ class StoryTeller::Story
     end
 
     @attributes = StoryTeller::Attributes.new(attrs)
-
-    unless @attributes.valid?
-      raise StoryAttributeMissingError, "Invalid story. Requires a message"
-    end
 
     @level = level
     @timestamp = Time.now.utc

--- a/spec/story_teller/message_spec.rb
+++ b/spec/story_teller/message_spec.rb
@@ -4,21 +4,7 @@ describe StoryTeller::Message do
       template = "Danica\u{1f601}".force_encoding("US-ASCII")
 
       message = StoryTeller::Message.new(template)
-      expect(message.valid?).to eq(true)
       expect(message.send(:template).encoding.name).to eq("UTF-8")
-    end
-  end
-
-  context "#valid?" do
-    it "returns false if the template is empty" do
-      expect(StoryTeller::Message.new(nil).valid?).to eq(false)
-      expect(StoryTeller::Message.new("").valid?).to eq(false)
-    end
-
-    it "returns true if a template is present" do
-      message = StoryTeller::Message.new("Something")
-
-      expect(message.valid?).to eq(true)
     end
   end
 

--- a/spec/story_teller/story_spec.rb
+++ b/spec/story_teller/story_spec.rb
@@ -2,12 +2,6 @@ require "story_teller"
 
 describe StoryTeller::Story do
   context "initialize" do
-    it "will raise an error if no message was set for this story" do
-      expect {
-        StoryTeller::Story.new
-      }.to raise_error(StoryTeller::Story::StoryAttributeMissingError)
-    end
-
     it "handles a string as argument and takes it as a message" do
       message = "A message"
       story = StoryTeller::Story.new(message)

--- a/spec/story_teller_spec.rb
+++ b/spec/story_teller_spec.rb
@@ -55,18 +55,6 @@ describe StoryTeller do
     end
   end
 
-  it "will recover from any StandardError" do
-    expect {
-      StoryTeller.tell
-    }.to raise_error(StandardError)
-
-    expect {
-      StoryTeller.tell(
-        message: "Test"
-      )
-    }.to_not raise_error(StandardError)
-  end
-
   it "will return the same UUID associated with the current book" do
     uuid = StoryTeller.uuid
 


### PR DESCRIPTION
The main app has occurences where message are nil and so I don't want to
introduce a regression over there. Instead of forcing everyone to change
the code, I'm just making some changes to the code so StoryTeller can be
backward compatible with the structure we already have in place on the
main app.

It's possible in the future it is reintroduce, but that will have to be
discussed with every users of ST.