### PR TITLE
Convert any template to strings

### DIFF
--- a/lib/story_teller/message.rb
+++ b/lib/story_teller/message.rb
@@ -4,14 +4,10 @@ class StoryTeller::Message
   NIL_STRING = ""
 
   def initialize(template)
-    if template.nil?
-      @template = ""
-      return
-    end
+    template = template.to_s
 
     unless template.encoding.name == "UTF-8"
-      @template = template.encode("UTF-8", invalid: :replace)
-      return
+      template = template.encode("UTF-8", invalid: :replace)
     end
 
     @template = template

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require "story_teller"
 require "byebug"
-require "rails"
+require "rails/all"
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|

--- a/spec/story_teller/message_spec.rb
+++ b/spec/story_teller/message_spec.rb
@@ -6,6 +6,16 @@ describe StoryTeller::Message do
       message = StoryTeller::Message.new(template)
       expect(message.send(:template).encoding.name).to eq("UTF-8")
     end
+
+    it "can handle nil messages" do
+      message = StoryTeller::Message.new(nil)
+      expect(message.send(:template)).to eq("")
+    end
+
+    it "can handle non-string messages" do
+      message = StoryTeller::Message.new([])
+      expect(message.send(:template)).to eq("[]")
+    end
   end
 
   context "#render" do


### PR DESCRIPTION
The StoryTeller lib in the main app was way more permissive about a few things, so I need to make sure we can handle these cases first.

Eventually, we'll want to tighten up the API, but I can't do it now without changing a bunch of code in the main app.