### PR TITLE
Always return nil in StoryTeller.tell

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    story_teller (0.0.4.alpha)
+    story_teller (0.0.9)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/story_teller/book.rb
+++ b/lib/story_teller/book.rb
@@ -41,9 +41,9 @@ class StoryTeller::Book
     rescue Encoding::UndefinedConversionError, Encoding::InvalidByteSequenceError => e
       story = StoryTeller::Error.new(e)
       @dispatcher.submit(to_json(story))
-    ensure
-      nil
     end
+
+    nil
   end
 
   def current_chapter

--- a/lib/story_teller/version.rb
+++ b/lib/story_teller/version.rb
@@ -4,7 +4,7 @@ module StoryTeller
   module Version
     MAJOR = 0
     MINOR = 0
-    PATCH = 8
+    PATCH = 9
     BUILD = ""
 
     def self.to_s


### PR DESCRIPTION
Depending on what dispatcher is used, a different return value could be returned from StoryTeller.tell. We ran into this where in the test environment nil was being returned, but true was being returned in production.

This changes the method to always return nil regardless of what dispatcher is used.